### PR TITLE
Stash size workaround

### DIFF
--- a/src/DiIiS-NA/BGS-Server/AccountsSystem/GameAccountManager.cs
+++ b/src/DiIiS-NA/BGS-Server/AccountsSystem/GameAccountManager.cs
@@ -76,9 +76,9 @@ namespace DiIiS_NA.LoginServer.AccountsSystem
 				ParagonLevelHardcore = 0,
 				Experience = 7200000,
 				ExperienceHardcore = 7200000,
-				StashSize = 70,
-				HardcoreStashSize = 70,
-				SeasonStashSize = 70,
+				StashSize = 700,			// Default stash sizes should be 70 with purchasable upgrades
+				HardcoreStashSize = 700,
+				SeasonStashSize = 700,
 				BloodShards = 0,
 				HardcoreBloodShards = 0,
 				BossProgress = new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff },

--- a/src/DiIiS-NA/D3-GameServer/GSSystem/PlayerSystem/Inventory.cs
+++ b/src/DiIiS-NA/D3-GameServer/GSSystem/PlayerSystem/Inventory.cs
@@ -2418,8 +2418,7 @@ namespace DiIiS_NA.GameServer.GSSystem.PlayerSystem
 				_owner.World.Game.GameDBSession.SessionGet<DBGameAccount>(_owner.Toon.GameAccount.PersistentID).StashSize;
 			if (slots > 0)
 			{
-				//_owner.Attributes[GameAttribute.Shared_Stash_Slots] = slots;
-				_owner.Attributes[GameAttribute.Shared_Stash_Slots] = 700;	// HACK: Give player 10 stash tabs. Remove this when tab purchasing gets fixed.
+				_owner.Attributes[GameAttribute.Shared_Stash_Slots] = slots;
 				_owner.Attributes.BroadcastChangedIfRevealed();
 				// To be applied before loading items, to have all the space needed
 				_stashGrid.ResizeGrid(_owner.Attributes[GameAttribute.Shared_Stash_Slots] / 7, 7);

--- a/src/DiIiS-NA/D3-GameServer/GSSystem/PlayerSystem/Inventory.cs
+++ b/src/DiIiS-NA/D3-GameServer/GSSystem/PlayerSystem/Inventory.cs
@@ -2418,7 +2418,8 @@ namespace DiIiS_NA.GameServer.GSSystem.PlayerSystem
 				_owner.World.Game.GameDBSession.SessionGet<DBGameAccount>(_owner.Toon.GameAccount.PersistentID).StashSize;
 			if (slots > 0)
 			{
-				_owner.Attributes[GameAttribute.Shared_Stash_Slots] = slots;
+				//_owner.Attributes[GameAttribute.Shared_Stash_Slots] = slots;
+				_owner.Attributes[GameAttribute.Shared_Stash_Slots] = 700;	// HACK: Give player 10 stash tabs. Remove this when tab purchasing gets fixed.
 				_owner.Attributes.BroadcastChangedIfRevealed();
 				// To be applied before loading items, to have all the space needed
 				_stashGrid.ResizeGrid(_owner.Attributes[GameAttribute.Shared_Stash_Slots] / 7, 7);

--- a/src/DiIiS-NA/D3-GameServer/GSSystem/PlayerSystem/Player.cs
+++ b/src/DiIiS-NA/D3-GameServer/GSSystem/PlayerSystem/Player.cs
@@ -468,7 +468,6 @@ namespace DiIiS_NA.GameServer.GSSystem.PlayerSystem
 			Attributes[GameAttribute.Buff_Icon_Count0, 0x00033C40] = 1;
 			
 			Attributes[GameAttribute.Currencies_Discovered] = 0x0011FFF8;
-			Attributes[GameAttribute.Stash_Tabs_Purchased_With_Gold] = 5;
 
 			this.Attributes[GameAttribute.Skill, 30592] = 1;
 			this.Attributes[GameAttribute.Resource_Degeneration_Prevented] = false;
@@ -622,7 +621,8 @@ namespace DiIiS_NA.GameServer.GSSystem.PlayerSystem
 			this.Attributes[GameAttribute.Cannot_Dodge] = false;
 			this.Attributes[GameAttribute.Trait, 0x0000CE11] = 1;
 			this.Attributes[GameAttribute.TeamID] = 2;
-			this.Attributes[GameAttribute.Stash_Tabs_Purchased_With_Gold] = 1;
+			this.Attributes[GameAttribute.Stash_Tabs_Purchased_With_Gold] = 5;			// what do these do?
+			this.Attributes[GameAttribute.Stash_Tabs_Rewarded_By_Achievements] = 5;
 			this.Attributes[GameAttribute.Backpack_Slots] = 60;
 			this.Attributes[GameAttribute.General_Cooldown] = 0;
 		}


### PR DESCRIPTION
Increased default stash size for new accounts from 1 to 10 tabs as a temporary workaround for buying stash tabs with gold not working. This needs a proper fix in future.