### PR TITLE
Resurrection and potion fixes

### DIFF
--- a/src/DiIiS-NA/D3-GameServer/GSSystem/ItemsSystem/Item.cs
+++ b/src/DiIiS-NA/D3-GameServer/GSSystem/ItemsSystem/Item.cs
@@ -929,6 +929,7 @@ namespace DiIiS_NA.GameServer.GSSystem.ItemsSystem
 
 				player.World.PowerManager.RunPower(player, 30211);
 
+				/* Potions are no longer consumable
 				if (this.Attributes[GameAttribute.ItemStackQuantityLo] <= 1)
 					player.Inventory.DestroyInventoryItem(this); // No more potions!
 				else
@@ -936,6 +937,8 @@ namespace DiIiS_NA.GameServer.GSSystem.ItemsSystem
 					this.UpdateStackCount(--this.Attributes[GameAttribute.ItemStackQuantityLo]); // Just remove one
 					this.Attributes.SendChangedMessage(player.InGameClient);
 				}
+				*/
+
 				return;
 			}
 

--- a/src/DiIiS-NA/D3-GameServer/GSSystem/ItemsSystem/Item.cs
+++ b/src/DiIiS-NA/D3-GameServer/GSSystem/ItemsSystem/Item.cs
@@ -927,8 +927,7 @@ namespace DiIiS_NA.GameServer.GSSystem.ItemsSystem
 				if (player.Attributes[GameAttribute.Hitpoints_Cur] == player.Attributes[GameAttribute.Hitpoints_Max])
 					return;
 
-				player.AddPercentageHP(60);
-				player.World.BuffManager.AddBuff(this, player, new PowerSystem.Implementations.CooldownBuff(30211, TickTimer.WaitSeconds(player.World.Game, 30f)));
+				player.World.PowerManager.RunPower(player, 30211);
 
 				if (this.Attributes[GameAttribute.ItemStackQuantityLo] <= 1)
 					player.Inventory.DestroyInventoryItem(this); // No more potions!

--- a/src/DiIiS-NA/D3-GameServer/GSSystem/MapSystem/World.cs
+++ b/src/DiIiS-NA/D3-GameServer/GSSystem/MapSystem/World.cs
@@ -875,7 +875,7 @@ namespace DiIiS_NA.GameServer.GSSystem.MapSystem
 		}
 		public void SpawnRandomPotion(Actor source, Player player)
 		{
-			if (player != null && !player.Inventory.HaveEnough(DiIiS_NA.Core.Helpers.Hash.StringHashHelper.HashItemName("HealthPotionBottomless"), 100))
+			if (player != null && !player.Inventory.HaveEnough(DiIiS_NA.Core.Helpers.Hash.StringHashHelper.HashItemName("HealthPotionBottomless"), 1))
 			{
 				var item = ItemGenerator.GenerateRandomPotion(player);
 				if (item == null) return;

--- a/src/DiIiS-NA/D3-GameServer/GSSystem/PlayerSystem/Player.cs
+++ b/src/DiIiS-NA/D3-GameServer/GSSystem/PlayerSystem/Player.cs
@@ -2461,8 +2461,11 @@ namespace DiIiS_NA.GameServer.GSSystem.PlayerSystem
 						}
 					}
 				}
+
+				this.Attributes[GameAttribute.Corpse_Resurrection_Charges] = 3;		// Reset resurrection charges on zone change (TODO: do not reset charges on reentering the same zone)
+
 #if DEBUG
-				Logger.Warn("Местополежение игрока {0}, Scene: {1} SNO: {2} LevelArea: {3}", this.Toon.Name, this.CurrentScene.SceneSNO.Name, this.CurrentScene.SceneSNO.Id, this.CurrentScene.Specification.SNOLevelAreas[0]);
+				Logger.Warn("Местоположение игрока {0}, Scene: {1} SNO: {2} LevelArea: {3}", this.Toon.Name, this.CurrentScene.SceneSNO.Name, this.CurrentScene.SceneSNO.Id, this.CurrentScene.Specification.SNOLevelAreas[0]);
 #else
 
 #endif
@@ -2653,7 +2656,11 @@ namespace DiIiS_NA.GameServer.GSSystem.PlayerSystem
 					this.Revive(this.CheckPointPosition);
 					break;
 				case 2:
-					//this.Revive(this.Position);
+					if (this.Attributes[GameAttribute.Corpse_Resurrection_Charges] > 0)
+					{
+						this.Revive(this.Position);
+						this.Attributes[GameAttribute.Corpse_Resurrection_Charges]--;
+					}
 					break;
 			}
 		}
@@ -3811,8 +3818,8 @@ namespace DiIiS_NA.GameServer.GSSystem.PlayerSystem
 				this.Attributes[GameAttribute.Resurrect_As_Observer] = state;
 				//this.Attributes[GameAttribute.Observer] = !state;
 			}
-			//this.Attributes[GameAttribute.Corpse_Resurrection_Charges] = 1;	//enable that to allow resurrecting at corpse
-			//this.Attributes[GameAttribute.Corpse_Resurrection_Allowed_Game_Time] = this.World.Game.TickCounter + 300; //timer for auto-revive
+			//this.Attributes[GameAttribute.Corpse_Resurrection_Charges] = 1;	// Enable this to allow unlimited resurrection at corpse
+			//this.Attributes[GameAttribute.Corpse_Resurrection_Allowed_Game_Time] = this.World.Game.TickCounter + 300; // Timer for auto-revive (seems to be broken?)
 			this.Attributes.BroadcastChangedIfRevealed();
 		}
 

--- a/src/DiIiS-NA/D3-GameServer/GSSystem/PowerSystem/Implementations/General/DrinkHealthPotion.cs
+++ b/src/DiIiS-NA/D3-GameServer/GSSystem/PowerSystem/Implementations/General/DrinkHealthPotion.cs
@@ -1,0 +1,24 @@
+﻿//Blizzless Project 2022 
+using System.Collections.Generic;
+using DiIiS_NA.GameServer.GSSystem.PlayerSystem;
+using DiIiS_NA.GameServer.GSSystem.TickerSystem;
+
+namespace DiIiS_NA.GameServer.GSSystem.PowerSystem.Implementations.General
+{
+    //30211   class DrinkHealthPotion
+    [ImplementsPowerSNO(30211)]
+    public class DrinkHealthPotion : PowerScript
+    {
+        public override IEnumerable<TickTimer> Run()
+        {
+            if (User is Player)
+            {
+                Player player = (Player)User;
+                player.AddPercentageHP(60);
+                AddBuff(player, player, new CooldownBuff(30211, TickTimer.WaitSeconds(player.World.Game, 30f)));
+            }
+
+            yield break;
+        }
+    }
+}

--- a/src/DiIiS-NA/D3-GameServer/MessageSystem/GameAttirbute.List.cs
+++ b/src/DiIiS-NA/D3-GameServer/MessageSystem/GameAttirbute.List.cs
@@ -375,9 +375,9 @@ namespace DiIiS_NA.GameServer.MessageSystem
         public static readonly GameAttributeF World_Seed = new GameAttributeF(758, 0, -1, 0, 0, "", "", "World_Seed", GameAttributeEncoding.Float32, 0, 0, 0, 32);
         public static readonly GameAttributeF Combo_Time_Last_Move = new GameAttributeF(802, 0, -1, 0, 0, "", "", "Combo_Time_Last_Move", GameAttributeEncoding.Float32, 0, 0, 0, 32);
         public static readonly GameAttributeF Death_Replacement_Effect_Group_SNO = new GameAttributeF(804, -1, -1, 0, 0, "", "", "Death_Replacement_Effect_Group_SNO", GameAttributeEncoding.Float32, 0, 0, 0, 32);
-        public static readonly GameAttributeF Checkpoint_Resurrection_Allowed_Game_Time = new GameAttributeF(805, 0, -1, 0, 0, "", "", "Checkpoint_Resurrection_Allowed_Game_Time", GameAttributeEncoding.Float32, 0, 0, 0, 32);
-        public static readonly GameAttributeF Checkpoint_Resurrection_Forced_Game_Time = new GameAttributeF(806, 0, -1, 0, 0, "", "", "Checkpoint_Resurrection_Forced_Game_Time", GameAttributeEncoding.Float32, 0, 0, 0, 32);
-        public static readonly GameAttributeF Corpse_Resurrection_Allowed_Game_Time = new GameAttributeF(807, 0, -1, 0, 0, "", "", "Corpse_Resurrection_Allowed_Game_Time", GameAttributeEncoding.Float32, 0, 0, 0, 32);
+        public static readonly GameAttributeI Checkpoint_Resurrection_Allowed_Game_Time = new GameAttributeI(805, 0, -1, 0, 0, "", "", "Checkpoint_Resurrection_Allowed_Game_Time", GameAttributeEncoding.Int, 0, 0, 0, 32);
+        public static readonly GameAttributeI Checkpoint_Resurrection_Forced_Game_Time = new GameAttributeI(806, 0, -1, 0, 0, "", "", "Checkpoint_Resurrection_Forced_Game_Time", GameAttributeEncoding.Int, 0, 0, 0, 32);
+        public static readonly GameAttributeI Corpse_Resurrection_Allowed_Game_Time = new GameAttributeI(807, 0, -1, 0, 0, "", "", "Corpse_Resurrection_Allowed_Game_Time", GameAttributeEncoding.Int, 0, 0, 0, 32);
         public static readonly GameAttributeF Controlling_TimedEvent_SNO = new GameAttributeF(810, -1, -1, 0, 0, "", "", "Controlling_TimedEvent_SNO", GameAttributeEncoding.Float32, 0, 0, 0, 32);
         public static readonly GameAttributeF Spawner_Concurrent_Count_ID = new GameAttributeF(855, -1, -1, 0, 0, "", "", "Spawner_Concurrent_Count_ID", GameAttributeEncoding.Float32, 0, 0, 0, 32);
         public static readonly GameAttributeI Skill_Override = new GameAttributeI(857, -1, -1, 0, 0, "", "", "Skill_Override", GameAttributeEncoding.Int, 136, 0, 0, 32);


### PR DESCRIPTION
**Resurrection**
- Fixed resurrection time attributes encoding (Checkpoint_Resurrection_Allowed_Game_Time, Checkpoint_Resurrection_Forced_Game_Time, Corpse_Resurrection_Allowed_Game_Time). Note: these properties don't seem to be properly implemented yet, so they require further testing in future.
- Fixed resurrect at corpse option (3 revive charges per zone, charges reset when entering a zone). Note: revive charges shouldn't reset when reentering the same zone, need some way to track if a zone has been visited already.

**Potions**
- Moved health potion implementation to a power to prepare to remove regular potions from the inventory entirely.
- Disabled potion consumption on use.
- Reduced potion cap from 100 to 1, so players won't get any more potion drops if they already have one.