### PR TITLE
Act 2 progression workaround and resurrect at corpse tweak

### DIFF
--- a/src/DiIiS-NA/D3-GameServer/GSSystem/ActorSystem/Implementations/Checkpoint.cs
+++ b/src/DiIiS-NA/D3-GameServer/GSSystem/ActorSystem/Implementations/Checkpoint.cs
@@ -33,6 +33,7 @@ namespace DiIiS_NA.GameServer.GSSystem.ActorSystem.Implementations
 				});
 
 				player.CheckPointPosition = this.Position;
+				player.Attributes[GameAttribute.Corpse_Resurrection_Charges] = 3;     // Reset corpse resurrection charges
 			}
 		}
 

--- a/src/DiIiS-NA/D3-GameServer/GSSystem/PlayerSystem/Player.cs
+++ b/src/DiIiS-NA/D3-GameServer/GSSystem/PlayerSystem/Player.cs
@@ -1336,6 +1336,8 @@ namespace DiIiS_NA.GameServer.GSSystem.PlayerSystem
 
 			this.Attributes[GameAttribute.Hitpoints_Cur] = this.Attributes[GameAttribute.Hitpoints_Max_Total];
 
+			this.Attributes[GameAttribute.Corpse_Resurrection_Charges] = 3;
+
 			//TestOutPutItemAttributes(); //Activate this only for finding item stats.
 			this.Attributes.BroadcastChangedIfRevealed();
 
@@ -2461,8 +2463,6 @@ namespace DiIiS_NA.GameServer.GSSystem.PlayerSystem
 						}
 					}
 				}
-
-				this.Attributes[GameAttribute.Corpse_Resurrection_Charges] = 3;		// Reset resurrection charges on zone change (TODO: do not reset charges on reentering the same zone)
 
 #if DEBUG
 				Logger.Warn("Местоположение игрока {0}, Scene: {1} SNO: {2} LevelArea: {3}", this.Toon.Name, this.CurrentScene.SceneSNO.Name, this.CurrentScene.SceneSNO.Id, this.CurrentScene.Specification.SNOLevelAreas[0]);

--- a/src/DiIiS-NA/D3-GameServer/GSSystem/PlayerSystem/Player.cs
+++ b/src/DiIiS-NA/D3-GameServer/GSSystem/PlayerSystem/Player.cs
@@ -5958,7 +5958,7 @@ namespace DiIiS_NA.GameServer.GSSystem.PlayerSystem
 			minion.SetVisible(true);
 			minion.Hidden = false;
 
-			if (minion.ActorSNO.Id == 4580)
+			if (minion.ActorSNO.Id == 4580)		// Act I Leah
 			{
 				(minion.Brain as MinionBrain).PresetPowers.Clear();
  				(minion.Brain as MinionBrain).AddPresetPower(30599);

--- a/src/DiIiS-NA/D3-GameServer/GSSystem/QuestSystem/ActII.cs
+++ b/src/DiIiS-NA/D3-GameServer/GSSystem/QuestSystem/ActII.cs
@@ -133,7 +133,8 @@ namespace DiIiS_NA.GameServer.GSSystem.QuestSystem
 					//ListenProximity(85843, new SpawnCultists());
 					script = new SpawnCultists();
 					script.Execute(this.Game.GetWorld(70885));
-					ListenKill(6027, 7, new Advance());
+					//ListenKill(6027, 7, new Advance());
+					ListenProximity(85843, new Advance());		// HACK: Skip ambush
 				})
 			});
 


### PR DESCRIPTION
- Implemented a workaround for Shadows in the Desert quest in Act 2.
- Moved resurrect at corpse charge reset to checkpoints (seems more accurate and less abusable).