### PR TITLE
Fixed some multiple enumerations

### DIFF
--- a/src/DiIiS-NA/D3-GameServer/AchievementSystem/AchievementManager.cs
+++ b/src/DiIiS-NA/D3-GameServer/AchievementSystem/AchievementManager.cs
@@ -474,25 +474,25 @@ namespace DiIiS_NA.GameServer.AchievementSystem
 
 		public static void CheckLevelCap(BattleClient client)
 		{
-			var capped_toons = DBSessions.SessionQueryWhere<DBToon>(dbt =>
+			var cappedToons = DBSessions.SessionQueryWhere<DBToon>(dbt =>
 						dbt.DBGameAccount.Id == client.Account.GameAccount.PersistentID &&
 						dbt.Level == 60);
-			if (capped_toons.Count() >= 2)
+			if (cappedToons.Count >= 2)
 				GrantAchievement(client, 74987243307116);
-			if (capped_toons.Count() >= 5)
+			if (cappedToons.Count >= 5)
 				GrantAchievement(client, 74987243307118);
-			if (capped_toons.Count() >= 10)
+			if (cappedToons.Count >= 10)
 				GrantAchievement(client, 74987243307120);
 
-			int different_classes = 0;
+			int differentClasses = 0;
 
-			foreach (ToonClass toon_class in (ToonClass[])Enum.GetValues(typeof(ToonClass)))
+			foreach (ToonClass toonClass in Enum.GetValues<ToonClass>())
 			{
-				var toons = capped_toons.Where(t => t.Class == toon_class);
-				if (toons.Count() > 0) different_classes++;
-				if (toons.Count() >= 2)
+				var toons = cappedToons.Where(t => t.Class == toonClass).ToArray();
+				if (toons.Length > 0) differentClasses++;
+				if (toons.Length >= 2)
 				{
-					switch (toon_class)
+					switch (toonClass)
 					{
 						case ToonClass.Barbarian:
 							GrantAchievement(client, 74987243307044);
@@ -513,10 +513,10 @@ namespace DiIiS_NA.GameServer.AchievementSystem
 				}
 			}
 
-			if (different_classes >= 2)
+			if (differentClasses >= 2)
 				GrantAchievement(client, 74987243307121);
 
-			if (different_classes >= 5)
+			if (differentClasses >= 5)
 				GrantAchievement(client, 74987243307362);
 		}
 

--- a/src/DiIiS-NA/D3-GameServer/GSSystem/PowerSystem/Implementations/HeroSkills/Crusader.cs
+++ b/src/DiIiS-NA/D3-GameServer/GSSystem/PowerSystem/Implementations/HeroSkills/Crusader.cs
@@ -302,18 +302,21 @@ namespace DiIiS_NA.GameServer.GSSystem.PowerSystem.Implementations
 
 			yield return WaitSeconds(0.2f);
 
-			var additional_targets = GetEnemiesInRadius(User.Position, ScriptFormula(3)).Actors.OrderBy(actor => PowerMath.Distance2D(actor.Position, User.Position)).Take((int)ScriptFormula(4));
+			var additionalTargets = GetEnemiesInRadius(User.Position, ScriptFormula(3)).Actors
+				.OrderBy(actor => PowerMath.Distance2D(actor.Position, User.Position))
+				.Take((int)ScriptFormula(4))
+				.ToArray();
 
-			foreach (var target in additional_targets)
+			foreach (var target in additionalTargets)
 			{
 				target.PlayEffectGroup(RuneSelect(336292, 338256, 338255, 338254, 343105, 336292));
-				AttackPayload additional_attack = new AttackPayload(this);
-				additional_attack.SetSingleTarget(target);
-				additional_attack.AddWeaponDamage(ScriptFormula(9), DamageType.Holy);
-				additional_attack.Apply();
+				AttackPayload additionalAttack = new AttackPayload(this);
+				additionalAttack.SetSingleTarget(target);
+				additionalAttack.AddWeaponDamage(ScriptFormula(9), DamageType.Holy);
+				additionalAttack.Apply();
 				if (Rune_A > 0)         //Shared fates (buff slot 0)
-					foreach (var otherTarget in additional_targets)
-						if (!(otherTarget == target))
+					foreach (var otherTarget in additionalTargets)
+						if (otherTarget != target)
 							if (PowerMath.Distance2D(otherTarget.Position, target.Position) > 10f)      //for now
 								if (!HasBuff<DebuffStunned>(otherTarget))
 									AddBuff(otherTarget, new DebuffStunned(WaitSeconds(ScriptFormula(32))));
@@ -324,14 +327,12 @@ namespace DiIiS_NA.GameServer.GSSystem.PowerSystem.Implementations
 
 				if (Rune_C > 0)         //Shatter
 				{
-					AttackPayload explosion_attack = new AttackPayload(this);
-					explosion_attack.Targets = GetEnemiesInRadius(target.Position, ScriptFormula(23));
-					explosion_attack.AddWeaponDamage(ScriptFormula(6), DamageType.Holy);
-					explosion_attack.Apply();
+					AttackPayload explosionAttack = new AttackPayload(this);
+					explosionAttack.Targets = GetEnemiesInRadius(target.Position, ScriptFormula(23));
+					explosionAttack.AddWeaponDamage(ScriptFormula(6), DamageType.Holy);
+					explosionAttack.Apply();
 				}
 			}
-
-			yield break;
 		}
 
 		[ImplementsPowerBuff(1, true)]


### PR DESCRIPTION
Let me explain the problem using some example:
```
var someEnumerable = someSource.Where(x => x > 10);
for(...)
{
    if (someEnumerable.Count())
}
```

So here we actually filter (`someSource.Where(x => x > 10)`) on each loop iteration when we call `Count()`.